### PR TITLE
Add DUOS urls to whitelist

### DIFF
--- a/src/whitelist.js
+++ b/src/whitelist.js
@@ -6,5 +6,8 @@ module.exports = [
   'https://all-of-us-rw-perf.appspot.com',
   'https://all-of-us-rw-preprod.appspot.com',
   'https://workbench.researchallofus.org',
-  'https://app.terra.bio'
+  'https://app.terra.bio',
+  'https://duos.broadinstitute.org',
+  'https://duos.dsp-duos-staging.broadinstitute.org',
+  'https://duos.dsp-duos-dev.broadinstitute.org'
 ]


### PR DESCRIPTION
## Addresses
DUOS Ticket: https://broadinstitute.atlassian.net/browse/DUOS-488
DDO Ticket: https://broadworkbench.atlassian.net/browse/DDO-462

## Changes
* Minor addition of the dev, staging, and prod DUOS urls to the whitelist.