### PR TITLE
[CA-1048] Make dev payload consistent with prod payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ The dev flow is used by various unit and integration tests in firecloud-orchestr
 to decrypt and verify the JWT it receives. The tests store tokens that have been encoded using Shibboleth's dev private key. If we ever need to rotate
 Shibboleth's dev keys, we will need to update those stored tokens to ensure unit and integration tests continue to function.
 
-Integration test tokens are stored in [each service's application.conf template](https://github.com/broadinstitute/firecloud-automated-testing/tree/master/configs). Unit test tokens are stored in the [firecloud-orchestration repo](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala).
+Integration test tokens are stored in [each service's application.conf template in the firecloud-automated-testing repo](https://github.com/broadinstitute/firecloud-automated-testing/tree/master/configs). Unit test tokens are stored in the [firecloud-orchestration repo](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala).

--- a/README.md
+++ b/README.md
@@ -68,3 +68,10 @@ tar -c --exclude='./node_modules/*' . \
 
 The Shibboleth Service Provider is hosted on Google App Engine as a single application which supports both the development and production workflows.
 Google Cloud Build deploys a new version of the application automatically when commits are merged to the `master` branch. 
+
+## Key Rotation
+The dev flow is used by various unit and integration tests in firecloud-orchestration. Firecloud Orchestration pulls Shibboleth's current dev public key in order
+to decrypt and verify the JWT it receives. The tests store tokens that have been encoded using Shibboleth's dev private key. If we ever need to rotate
+Shibboleth's dev keys, we will need to update those stored tokens to ensure unit and integration tests continue to function.
+
+Integration test tokens are stored in [each service's application.conf template](https://github.com/broadinstitute/firecloud-automated-testing/tree/master/configs). Unit test tokens are stored in the [firecloud-orchestration repo](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala).

--- a/src/main.js
+++ b/src/main.js
@@ -166,7 +166,7 @@ app.post('/dev/login', withConfig, async (req, res, next) => {
   const cleaned = decodeUriEncoded(body.toString(), true)
   const cookies = decodeUriEncoded(req.get('cookie'))
   const fakeUsername = cleaned.fakeUsername.length === 0 ? undefined : cleaned.fakeUsername
-  const payload = {'fake-era-commons-username': fakeUsername}
+  const payload = {'eraCommonsUsername': fakeUsername}
   const privateKey = req.config.data.devKeyPrivate
   const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'})
   const returnUrl = cookies['return-url'].replace('<token>', token)


### PR DESCRIPTION
Ticket: [CA-1048](https://broadworkbench.atlassian.net/browse/CA-1048)

Changing the username key in the dev payload consistent with the prod payload made it much easier to make Orch compatible with Shibboleth. This will break the dev flow in non-production Terra until the Orch changes go out, but I don't think that's a big deal. Still, I will hold off on releasing this until the Orch changes are ready to go so that it won't be broken for too long.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've updated the description of this change and its security impact in the Jira issue
- [x] I've tested that the development workflow passes on a locally running instance

In all cases:

- [x] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
