### PR TITLE
Update config to point to new IDP certificate

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ const whitelist = require('whitelist')
 
 // TODO(dmohs): This doesn't make sense. Since I have to change code to update the config, there is
 // little value in this separation. Just inline the values here instead.
-const configPath = 'gs://broad-shibboleth-prod.appspot.com/configs/config.20200103a.json'
+const configPath = 'gs://broad-shibboleth-prod.appspot.com/configs/config.20210510a.json'
 
 function escapeHtml(html) {
   return html


### PR DESCRIPTION
Ticket: None. This is a response to an email from NIH warning about their certificate's looming expiration. Screenshot of email attached:

![screen_shot_2021-05-10_at_10 49 50_am](https://user-images.githubusercontent.com/1545444/117850342-31a72780-b253-11eb-89f9-d8c06a5aca3e.png)

Certificate updated and uploaded to the configuration bucket. Tested as follows:

1. `gcloud app deploy --no-promote --project=broad-shibboleth-prod`
2. Migrate traffic to new version
3. Test production flow manually

I have left the traffic migrated to this deployed version since it appears to work correctly. Merging this PR will cause a new deploy that will replace this manual deployment.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've updated the description of this change and its security impact in the Jira issue
- [ ] I've tested that the development workflow passes on a locally running instance

In all cases:

- [x] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
