### PR TITLE
Revert Cloud Build config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,25 +1,4 @@
 steps:
-- id: gcloud app deploy
-  name: "gcr.io/cloud-builders/gcloud"
+- name: "gcr.io/cloud-builders/gcloud"
   args: ["app", "deploy"]
-- id: Report deployment
-  name: 'launcher.gcr.io/google/ubuntu1604'
-  entrypoint: bash
-  args:
-  - -c
-  - >
-    AH='Accept: application/vnd.github.v3+json';
-    set -x;
-    curl -LO 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64';
-    chmod +x jq-linux64;
-    PRN="$(curl -H "$AH" -u "dmohs:$$GHTOKEN" https://api.github.com/search/issues?q=sha:$COMMIT_SHA+repo:broadinstitute/shibboleth-service-provider | ./jq-linux64 .items[0].number)";
-    curl -H "$AH"
-    -u "dmohs:$$GHTOKEN"
-    "https://api.github.com/repos/all-of-us/workbench/pulls/$PRN/reviews"
-    -d '{"body": "$SHORT_SHA deployed.", "event": "COMMENT"}'
-  secretEnv: ['GHTOKEN']
-availableSecrets:
-  secretManager:
-  - versionName: projects/336679256648/secrets/github-token/versions/1
-    env: GHTOKEN
 timeout: "1600s"


### PR DESCRIPTION
See #43. This reverts the changes.

While I like the idea of using PR comments to report status, this particular report may not be worthwhile. Iteration is very slow, partly because the `cloud-build-local` tool is not yet able to handle secrets from the Secret Manager. Meanwhile, Cloud Build does report success or failure, which becomes a checkmark or an X next to the commit in history.