### PR TITLE
[CA-1537]Support mustache-style token

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -166,7 +166,7 @@ app.post('/dev/login', withConfig, async (req, res, next) => {
   const payload = {'eraCommonsUsername': fakeUsername}
   const privateKey = req.config.data.devKeyPrivate
   const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'})
-  const returnUrl = cookies['return-url'].replace('<token>', token)
+  const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
   res.send([
     '<h2>"Sign-In" Successful!</h2>',
     `<p>fake username: <b>${escapeHtml(fakeUsername)}</b></p>`,
@@ -295,7 +295,7 @@ app.post("/assert", [withSp, withIdp], bodyParser.urlencoded({extended: true}), 
       const privateKey = req.config.data.prodKeyPrivate
       const payload = {eraCommonsUsername: samlResponse.user.name_id}
       const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'})
-      const returnUrl = cookies['return-url'].replace('<token>', token)
+      const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
       return redirectOrPause(res, returnUrl, token)
     } catch (e) {
       console.error(e)


### PR DESCRIPTION
Some systems fail to handle URLs with the string `<token>` present, even if encoded. Support an alternative format.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've updated the description of this change and its security impact in the Jira issue
- [ ] I've tested that the development workflow passes on a locally running instance

In all cases:

- [ ] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
