### PR TITLE
DUOS-1625: Update DUOS domain entries

### DIFF
--- a/src/whitelist.js
+++ b/src/whitelist.js
@@ -14,6 +14,7 @@ module.exports = [
   'https://baseline.terra.bio',
   'https://terra.biodatacatalyst.nhlbi.nih.gov',
   'https://duos.broadinstitute.org',
-  'https://duos.dsp-duos-staging.broadinstitute.org',
-  'https://duos.dsp-duos-dev.broadinstitute.org'
+  'https://duos.org',
+  'https://duos-k8s.dsde-staging.broadinstitute.org/',
+  'https://duos-k8s.dsde-dev.broadinstitute.org/'
 ]

--- a/src/whitelist.js
+++ b/src/whitelist.js
@@ -15,6 +15,6 @@ module.exports = [
   'https://terra.biodatacatalyst.nhlbi.nih.gov',
   'https://duos.broadinstitute.org',
   'https://duos.org',
-  'https://duos-k8s.dsde-staging.broadinstitute.org/',
-  'https://duos-k8s.dsde-dev.broadinstitute.org/'
+  'https://duos-k8s.dsde-staging.broadinstitute.org',
+  'https://duos-k8s.dsde-dev.broadinstitute.org'
 ]


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DUOS-1625

This PR updates the domain entries that DUOS uses.

**Local flow note:** Running this locally does not work according to the instructions. I've run this several times after logging in correctly as a firecloud.org user, but continue to get this error:

```
➜  shibboleth-service-provider git:(duos-orgs) npm start

> broad-shibboleth-sp@2020.01.09 start
> export NODE_PATH=/tmp/aelivedev/src:$PWD/src:$PWD/node_modules && node src/index.js

*** require.cache ***
/Users/grushton/develop/shibboleth-service-provider/src/index.js
/Users/grushton/develop/shibboleth-service-provider/src/main.js
/Users/grushton/develop/shibboleth-service-provider/src/auth.js
/Users/grushton/develop/shibboleth-service-provider/src/utils.js
/Users/grushton/develop/shibboleth-service-provider/src/config.js
/Users/grushton/develop/shibboleth-service-provider/src/whitelist.js
*** end ***
+ gcloud auth print-access-token
/Users/grushton/develop/shibboleth-service-provider/src/main.js:169
  const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
                                          ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at /Users/grushton/develop/shibboleth-service-provider/src/main.js:169:43
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```


I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've updated the description of this change and its security impact in the Jira issue
- [ ] I've tested that the development workflow passes on a locally running instance

In all cases:

- [x] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
