### PR TITLE
[ID-53] add expiration time to jwt (token)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -165,7 +165,7 @@ app.post('/dev/login', withConfig, async (req, res, next) => {
   const fakeUsername = cleaned.fakeUsername.length === 0 ? undefined : cleaned.fakeUsername
   const payload = {'eraCommonsUsername': fakeUsername}
   const privateKey = req.config.data.devKeyPrivate
-  const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '60s'})
+  const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '1h'})
   const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
   res.send([
     '<h2>"Sign-In" Successful!</h2>',
@@ -294,7 +294,7 @@ app.post("/assert", [withSp, withIdp], bodyParser.urlencoded({extended: true}), 
       const cookies = decodeUriEncoded(req.get('cookie'))
       const privateKey = req.config.data.prodKeyPrivate
       const payload = {eraCommonsUsername: samlResponse.user.name_id}
-      const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '60s'})
+      const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '1h'})
       const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
       return redirectOrPause(res, returnUrl, token)
     } catch (e) {

--- a/src/main.js
+++ b/src/main.js
@@ -165,7 +165,7 @@ app.post('/dev/login', withConfig, async (req, res, next) => {
   const fakeUsername = cleaned.fakeUsername.length === 0 ? undefined : cleaned.fakeUsername
   const payload = {'eraCommonsUsername': fakeUsername}
   const privateKey = req.config.data.devKeyPrivate
-  const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'})
+  const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '60m'})
   const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
   res.send([
     '<h2>"Sign-In" Successful!</h2>',
@@ -294,7 +294,7 @@ app.post("/assert", [withSp, withIdp], bodyParser.urlencoded({extended: true}), 
       const cookies = decodeUriEncoded(req.get('cookie'))
       const privateKey = req.config.data.prodKeyPrivate
       const payload = {eraCommonsUsername: samlResponse.user.name_id}
-      const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'})
+      const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '60m'})
       const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
       return redirectOrPause(res, returnUrl, token)
     } catch (e) {

--- a/src/main.js
+++ b/src/main.js
@@ -165,7 +165,7 @@ app.post('/dev/login', withConfig, async (req, res, next) => {
   const fakeUsername = cleaned.fakeUsername.length === 0 ? undefined : cleaned.fakeUsername
   const payload = {'eraCommonsUsername': fakeUsername}
   const privateKey = req.config.data.devKeyPrivate
-  const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '60m'})
+  const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '60s'})
   const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
   res.send([
     '<h2>"Sign-In" Successful!</h2>',
@@ -294,7 +294,7 @@ app.post("/assert", [withSp, withIdp], bodyParser.urlencoded({extended: true}), 
       const cookies = decodeUriEncoded(req.get('cookie'))
       const privateKey = req.config.data.prodKeyPrivate
       const payload = {eraCommonsUsername: samlResponse.user.name_id}
-      const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '60m'})
+      const token = jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '60s'})
       const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
       return redirectOrPause(res, returnUrl, token)
     } catch (e) {


### PR DESCRIPTION
Ticket: 
https://broadworkbench.atlassian.net/browse/CA-1751

AppSec found that the jwt does not have an expiration. This PR seeks to resolve this security finding.

[The JWT is used by Orchestration here](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala#L130), where the jwt is decoded and the data is stored. It doesn't seem like the jwt is stored or needs to exist after it is decoded. 

I believe the jwt is sent back to the system immediately (via callback/redirect) after the user signs into the NIH page, based on my test of linking my prod account to my NIH account. If it works as expected, I think the expiration time is as short as ~1-2 seconds. I will go with 1 ~minute~ hour to give some padding in case of nih/terra/user network slowness.

---
more context about why this change should be in Shibboleth and not Orch from David An:

> The JWT spec explicitly defines an exp claim: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4  exactly for this purpose, and any decent JWT library supports this claim.
> 
> I believe it is a one-line change to add the exp claim inside Shibboleth, e.g. jwt.sign(payload, privateKey, {algorithm: 'RS256', expiresIn: '10m'})` for a 10-minute token: [shibboleth-service-provider/main.js at a9e78cbba708394342c8047e42bc484b2004820f · broadinstitute/shibboleth-service-provider](https://github.com/broadinstitute/shibboleth-service-provider/blob/a9e78cbba708394342c8047e42bc484b2004820f/src/main.js#L297) (it’s a one-liner because the jsonwebtoken supports exp). The documentation for expiresIn is here: https://www.npmjs.com/package/jsonwebtoken 
> 
> In Orchestration, it is likely to be a ZERO-line change, because jwt-core supports the exp claim. Since we are already validating the token as a whole, if an exp claim is added, we’ll validate that. See https://jwt-scala.github.io/jwt-scala/jwt-core-jwt.html#options .
> 
> By suggesting we implement this fully in Orchestration, it incurs a much higher cost to implement custom logic against the iat claim, with accompanying unit tests and maintenance. I would rather rely on already-tested and widely-used open source libraries instead of writing our own validation logic.
> 
> Finally - at an architectural level - Shibboleth is the token creator in this scenario, and it should be the token creator who defines the token’s expiration; it should not be up to consuming services to define their own expirations.

https://broadworkbench.atlassian.net/browse/ID-53?focusedCommentId=60996

---

tested locally:

```
Example Return Page
header: {"alg":"RS256","typ":"JWT"}

payload: {"eraCommonsUsername":"fdas","iat":1654201490,"exp":1654205090}

Verification
dev: passed

prod: failed
```

and tested dev flow on appengine (https://aj-expire-token-dot-broad-shibboleth-prod.appspot.com/):

```
header: {"alg":"RS256","typ":"JWT"}

payload: {"eraCommonsUsername":"asdf","iat":1654201745,"exp":1654205345}

Verification
dev: passed

prod: failed
```


~Unresolved questions:~
~* do any other users of Shibboleth need an expiration time longer than 1 minute?~


I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've updated the description of this change and its security impact in the Jira issue
- [ ] I've tested that the development workflow passes on a locally running instance

In all cases:

- [ ] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
