### PR TITLE
[CA-1751] Add 1-hour expiration to JWT

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -45,7 +45,7 @@ function verifyJwt(token, publicKey) {
 function oneHourFromNowJwtTime() {
   // Type is NumericDate from https://datatracker.ietf.org/doc/html/rfc7519
   // a.k.a. seconds since January 1, 1970
-  const nowInSecondsSinceEpoch = Date.now() / 1000
+  const nowInSecondsSinceEpoch = Math.floor(Date.now() / 1000)
   return nowInSecondsSinceEpoch + (60 * 60 * 1)
 }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CA-1751

Adds an expiration time to the JWT, one hour from when issued. This is intended to be the maximum time any client should need to validate the JWT, depending upon their implementation. Clients should feel free to use a more conservative value based on the issue time if it suits their needs.

Tested the development flow manually. Prod flow should be tested after merge.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've updated the description of this change and its security impact in the Jira issue
- [ ] I've tested that the development workflow passes on a locally running instance

In all cases:

- [ ] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
