### PR TITLE
[ID-44] fix local dev flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -5,10 +5,10 @@ Ticket: \<Add link to Jira issue here\>
 Log any testing done, including none. A simple way to test is to:
 
 ```
-gcloud app deploy --project=broad-shibboleth-prod --version=my-version --no-promote
+gcloud app deploy --project=broad-shibboleth-prod --version=<your-version's-name> --no-promote
 ```
 
-You may then run through the development flow. If you need to also test the production flow, you may use the App Engine console to temporarily push traffic to your new version, run your test, then revert.
+You may then run through the development flow using the link provided by the command above. If you need to also test the production flow, you may use the App Engine console to temporarily push traffic to your new version, run your test, then revert.
 
 I, the developer opening this PR, do solemnly pinky swear that:
 

--- a/src/main.js
+++ b/src/main.js
@@ -161,12 +161,12 @@ app.get('/dev/login', (req, res, next) => {
 app.post('/dev/login', withConfig, async (req, res, next) => {
   const body = await u.consumeStreamp(req)
   const cleaned = decodeUriEncoded(body.toString(), true)
-  const cookies = decodeUriEncoded(req.get('cookie'))
+  const cookie = decodeUriEncoded(req.get('cookie'), true)
   const fakeUsername = cleaned.fakeUsername.length === 0 ? undefined : cleaned.fakeUsername
   const payload = {'eraCommonsUsername': fakeUsername}
   const privateKey = req.config.data.devKeyPrivate
   const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'})
-  const returnUrl = cookies['return-url'].replace('<token>', token).replace('{token}', token)
+  const returnUrl = cookie['return-url'].replace('<token>', token).replace('{token}', token)
   res.send([
     '<h2>"Sign-In" Successful!</h2>',
     `<p>fake username: <b>${escapeHtml(fakeUsername)}</b></p>`,
@@ -291,7 +291,7 @@ app.post("/assert", [withSp, withIdp], bodyParser.urlencoded({extended: true}), 
       return res.status(500)
     }
     try {
-      const cookies = decodeUriEncoded(req.get('cookie'))
+      const cookies = decodeUriEncoded(req.get('cookie'), true)
       const privateKey = req.config.data.prodKeyPrivate
       const payload = {eraCommonsUsername: samlResponse.user.name_id}
       const token = jwt.sign(payload, privateKey, {algorithm: 'RS256'})

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ function escapeHtml(html) {
 
 function decodeUriEncoded(s, shouldTrim = false) {
   const dec = decodeURIComponent
-  const kvs = s.split('&')
+  const kvs = s.split(/[&;]/) // '&' and ';' are both valid query delimiters
   const pairs = _.map((kv) => kv.split('='))(kvs)
   return _.fromPairs(
     _.map(([k, v]) => [dec(shouldTrim ? k.trim() : k), dec(shouldTrim ? v.trim() : v)])(pairs)


### PR DESCRIPTION
Ticket: \<Add link to Jira issue here\>
https://broadworkbench.atlassian.net/browse/ID-53



\<your comments for this PR go here\>

fixes local dev flow issues that I encountered while preparing to release https://github.com/broadinstitute/shibboleth-service-provider/pull/53. More details are in the commit history / comments

Log any testing done, including none. A simple way to test is to:

```
gcloud app deploy --project=broad-shibboleth-prod --version=my-version --no-promote
```

You may then run through the development flow. If you need to also test the production flow, you may use the App Engine console to temporarily push traffic to your new version, run your test, then revert.

---
I ran the [dev flow](https://github.com/broadinstitute/shibboleth-service-provider#how-to-execute-the-dev-flow) both Locally and with an instance deployed on appengine. I verified I was able to see the message "dev: passed" on the return page.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've updated the description of this change and its security impact in the Jira issue
- [ ] I've tested that the development workflow passes on a locally running instance

In all cases:

- [ ] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
