### PR TITLE
[no ticket]Update AoU stable hostname

### DIFF
--- a/src/whitelist.js
+++ b/src/whitelist.js
@@ -2,7 +2,7 @@ module.exports = [
   'https://broad-shibboleth-prod.appspot.com',
   'https://all-of-us-workbench-test.appspot.com',
   'https://all-of-us-rw-staging.appspot.com',
-  'https://all-of-us-rw-stable.appspot.com',
+  'https://stable.fake-research-aou.org',
   'https://all-of-us-rw-perf.appspot.com',
   'https://preprod-workbench.researchallofus.org',
   'https://workbench.researchallofus.org',


### PR DESCRIPTION
Workbench stable is now hosted from https://stable.fake-research-aou.org/. This is the same site, just a different domain. The old domain (https://all-of-us-rw-stable.appspot.com/) will stop working soon


Log any testing done, including none. A simple way to test is to:

```
gcloud app deploy --project=broad-shibboleth-prod --version=my-version --no-promote
```

You may then run through the development flow. If you need to also test the production flow, you may use the App Engine console to temporarily push traffic to your new version, run your test, then revert.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've updated the description of this change and its security impact in the Jira issue
- [ ] I've tested that the development workflow passes on a locally running instance

In all cases:

- [ ] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
