### PR TITLE
CORE-26, CORE-37: set Strict-Transport-Security and X-Content-Type-Options response headers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,14 @@ function verifyJwt(token, publicKey) {
 
 const app = express()
 
+// middleware to set global response headers
+app.use((req, res, next) => {
+  res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+  res.setHeader('X-Content-Type-Options', 'nosniff')
+  return next()
+})
+
+// middleware to check shibboleth url migration
 app.use((req, res, next) => {
   if (req.headers['host'] !== 'shibboleth.dsde-prod.broadinstitute.org') {
     return next()


### PR DESCRIPTION
Tickets:
* https://broadworkbench.atlassian.net/browse/CORE-26
* https://broadworkbench.atlassian.net/browse/CORE-37

What:

Sets `Strict-Transport-Security` and `X-Content-Type-Options` on all responses.


Why:

For better app security; these changes requested by appsec.

How:

Shibboleth uses [Express](https://expressjs.com/) as its framework. The implementation in this PR uses Express "middleware" to set response headers on all responses. 

See [this StackOverflow](https://stackoverflow.com/a/31661931) for a concise explanation of the approach.

See also the [App Engine documentation](https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=node.js#handlers_http_headers), which says:

> If you need to set HTTP headers in your script handlers, you should instead do that in your app's code.

---

Log any testing done, including none. A simple way to test is to:
* ran the [development flow](https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=node.js#handlers_http_headers) locally and inspected headers on each url.
* ran the server locally and inspected headers for `/hello`
* ran the server locally and inspected headers for `/metadata.xml`


I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've updated the description of this change and its security impact in the Jira issue
- [x] I've tested that the development workflow passes on a locally running instance

In all cases:

- [ ] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
