### PR TITLE
[CORE-157] Update IdP certificate

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 const _ = require('lodash/fp')
 const u = require('utils')
 
-const configPath = 'gs://broad-shibboleth-prod.appspot.com/configs/config.20230323a.json'
+const configPath = 'gs://broad-shibboleth-prod.appspot.com/configs/config.20241119a.json'
 
 async function fetchConfigData(authorization) {
   // console.log('fetchConfigData')


### PR DESCRIPTION
Ticket: [CORE-157](https://broadworkbench.atlassian.net/browse/CORE-157)

What:
Update to a new Identity Provider cert.

Why:
The old cert expires on December 5th, 2024.

How:
Shibboleth references the cert using its config file which contains the cert's file path in the bucket. I've uploaded the cert that I received from the NIH to Shibboleth's bucket and I've uploaded a new config file that points to this new cert as well. This PR points Shibboleth to the new config file which will in turn point it to the new IdP cert.

I followed the testing instructions below and the development flow and the login url for prod both continued to work on my test GAE version.

---

Log any testing done, including none. A simple way to test is to:

```
gcloud app deploy --project=broad-shibboleth-prod --version=<your-version's-name> --no-promote
```

You may then run through the development flow using the link provided by the command above. If you need to also test the production flow, you may use the App Engine console to temporarily push traffic to your new version, run your test, then revert.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've updated the description of this change and its security impact in the Jira issue
- [x] I've tested that the development workflow passes on a locally running instance

In all cases:

- [ ] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment


[CORE-157]: https://broadworkbench.atlassian.net/browse/CORE-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ