### PR TITLE
CORE-333: use nodejs 22 runtime

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs18
+runtime: nodejs22
 
 handlers:
 - url: /.*


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-333

## What:

Use nodejs22 runtime for App Engine

Why:

The current runtime, nodejs18, will hit end of support on April 30 2025

---

Log any testing done, including none:
* ran locally with node 22; saw success on the `/hello` page and the [dev flow](https://broadworkbench.atlassian.net/browse/CORE-333).


I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've updated the description of this change and its security impact in the Jira issue
- [x] I've tested that the development workflow passes on a locally running instance

In all cases:

- [x] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
