### PR TITLE
CORE-409: update saml2-js, which updates xml-crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "express": "^4.18.2",
         "jsonwebtoken": "9.0.0",
         "lodash": "^4.17.21",
-        "saml2-js": "4.0.2"
+        "saml2-js": "4.0.3"
       }
     },
     "node_modules/@oozcitak/dom": {
@@ -770,15 +770,15 @@
       "license": "MIT"
     },
     "node_modules/saml2-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-4.0.2.tgz",
-      "integrity": "sha512-03EEy/d55+4Ltl6jXAcRY1Fkrcpwt3K6a0T4N4Bfq5IKu9TbJqYG5AoXSi1P4lKvwvxQ99v5RPeoffSsumRrEg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-4.0.3.tgz",
+      "integrity": "sha512-lbQwkCuSgnogItacgaLM2YvVlCZxdcYSHtNfCgfGz+lKWfxBraP9i2iXzZjar2zIfBlpd+FMVH0ooOLkc5blPA==",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.6",
         "async": "^3.2.0",
         "debug": "^4.3.0",
         "underscore": "^1.8.0",
-        "xml-crypto": "^3.0.1",
+        "xml-crypto": "^3.2.1",
         "xml-encryption": "^3.0.2",
         "xmlbuilder2": "^2.4.0"
       },
@@ -983,15 +983,15 @@
       }
     },
     "node_modules/xml-crypto": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.0.1.tgz",
-      "integrity": "sha512-7XrwB3ujd95KCO6+u9fidb8ajvRJvIfGNWD0XLJoTWlBKz+tFpUzEYxsN+Il/6/gHtEs1RgRh2RH+TzhcWBZUw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.2.1.tgz",
+      "integrity": "sha512-0GUNbPtQt+PLMsC5HoZRONX+K6NBJEqpXe/lsvrFj0EqfpGPpVfJKGE7a5jCg8s2+Wkrf/2U1G41kIH+zC9eyQ==",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.5",
+        "@xmldom/xmldom": "^0.8.8",
         "xpath": "0.0.32"
       },
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xml-encryption": {
@@ -1556,15 +1556,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saml2-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-4.0.2.tgz",
-      "integrity": "sha512-03EEy/d55+4Ltl6jXAcRY1Fkrcpwt3K6a0T4N4Bfq5IKu9TbJqYG5AoXSi1P4lKvwvxQ99v5RPeoffSsumRrEg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-4.0.3.tgz",
+      "integrity": "sha512-lbQwkCuSgnogItacgaLM2YvVlCZxdcYSHtNfCgfGz+lKWfxBraP9i2iXzZjar2zIfBlpd+FMVH0ooOLkc5blPA==",
       "requires": {
         "@xmldom/xmldom": "^0.8.6",
         "async": "^3.2.0",
         "debug": "^4.3.0",
         "underscore": "^1.8.0",
-        "xml-crypto": "^3.0.1",
+        "xml-crypto": "^3.2.1",
         "xml-encryption": "^3.0.2",
         "xmlbuilder2": "^2.4.0"
       },
@@ -1709,11 +1709,11 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "xml-crypto": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.0.1.tgz",
-      "integrity": "sha512-7XrwB3ujd95KCO6+u9fidb8ajvRJvIfGNWD0XLJoTWlBKz+tFpUzEYxsN+Il/6/gHtEs1RgRh2RH+TzhcWBZUw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.2.1.tgz",
+      "integrity": "sha512-0GUNbPtQt+PLMsC5HoZRONX+K6NBJEqpXe/lsvrFj0EqfpGPpVfJKGE7a5jCg8s2+Wkrf/2U1G41kIH+zC9eyQ==",
       "requires": {
-        "@xmldom/xmldom": "^0.8.5",
+        "@xmldom/xmldom": "^0.8.8",
         "xpath": "0.0.32"
       }
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "express": "^4.18.2",
     "jsonwebtoken": "9.0.0",
     "lodash": "^4.17.21",
-    "saml2-js": "4.0.2"
+    "saml2-js": "4.0.3"
   },
   "scripts": {
     "start": "export NODE_PATH=/tmp/aelivedev/src:$PWD/src:$PWD/node_modules && node src/index.js"


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-409

What:

update saml2-js 4.0.2 -> 4.0.3. The saml2-js bump updates the transitive dependency xml-crypto.

Tested by running the [dev flow](https://github.com/broadinstitute/shibboleth-service-provider?tab=readme-ov-file#how-to-execute-the-dev-flow) locally.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've updated the description of this change and its security impact in the Jira issue
- [x] I've tested that the development workflow passes on a locally running instance

In all cases:

- [ ] Get two thumbs worth of review and PO sign off if necessary. 
- [ ] Squash and merge; you can delete your branch after this.
- [ ] Test this change deployed correctly and works after deployment
